### PR TITLE
Remove pyDOE and replace with qmc from scipy (for LHS)

### DIFF
--- a/apprentice/appset.py
+++ b/apprentice/appset.py
@@ -507,10 +507,12 @@ class TuningObjective2(object):
         if   method == "uniform":
             _PP = np.random.uniform(low=self._bounds[self._freeIdx][:,0], high=self._bounds[self._freeIdx][:,1], size=(ntrials, len(self._freeIdx[0])))
         elif method == "lhs":
-            import pyDOE2
+            from scipy.stats import qmc
+            sampler = qmc.LatinHypercube(ndim, seed)
+            sample = sampler.random(n=max(ntrials,2))
             a = self._bounds[self._freeIdx][:,0]
             b = self._bounds[self._freeIdx][:,1]
-            _PP = a + (b-a) * pyDOE2.lhs(len(self._freeIdx[0]), samples=max(ntrials,2), criterion="maximin")
+            _PP = qmc.scale(sample, a, b)
         else:
             raise Exception("Startpoint sampling method {} not known, exiting".format(method))
 

--- a/apprentice/appset.py
+++ b/apprentice/appset.py
@@ -508,7 +508,8 @@ class TuningObjective2(object):
             _PP = np.random.uniform(low=self._bounds[self._freeIdx][:,0], high=self._bounds[self._freeIdx][:,1], size=(ntrials, len(self._freeIdx[0])))
         elif method == "lhs":
             from scipy.stats import qmc
-            sampler = qmc.LatinHypercube(ndim, seed)
+            ndim = len(self._freeIdx[0])
+            sampler = qmc.LatinHypercube(ndim)
             sample = sampler.random(n=max(ntrials,2))
             a = self._bounds[self._freeIdx][:,0]
             b = self._bounds[self._freeIdx][:,1]

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
    'sklearn',
    # 'h5py>=2.8.0',
    'matplotlib>=3.0.0',
-   'pyDOE2>=1.3.0'
    # 'GPy>=1.9.9'
    # 'mpi4py>=3.0.0',
  ],


### PR DESCRIPTION
I replaced all pydoe2 code for lhs sampling with scipy's qmc equivalent and hence can drop pydoe from the list or required packages.